### PR TITLE
Calls split_nn_sapling.sh if low utxo count on NN

### DIFF
--- a/autodistsplit.sh
+++ b/autodistsplit.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Split NN script by phm87 (c) 2019
+# Call split_nn_sapling.sh if the utxo count on the NN_ADRESS it belox SPLIT_THRESHOLD
+# Inspired from cronsplit (webworker01) and from split_nn_sapling.sh (Decker)
+
+# Config
+
+NN_ADDRESS=RUjf7qQkUcVjkVeBgbrhCE4CpDH7fRuGyU
+SPLIT_VALUE=0.0001
+SPLIT_COUNT=3 # do not set split count > 252 (!), it's important
+SPLIT_THRESHOLD=5
+# Please configure split_nn_sapling.sh also
+
+# End of config
+
+
+SPLIT_VALUE_SATOSHI=$(jq -n "$SPLIT_VALUE*100000000")
+SPLIT_TOTAL=$(jq -n "$SPLIT_VALUE*$SPLIT_COUNT")
+SPLIT_TOTAL_SATOSHI=$(jq -n "$SPLIT_VALUE*$SPLIT_COUNT*100000000")
+
+# get listunspent from explorer, assumes komodo daemon is not available at this moment
+# (restart for example) or we don't have imported FROM privkey in the wallet.
+
+curl -s https://kmdexplorer.io/insight-api-komodo/addr/$NN_ADDRESS/utxo > nn.utxos
+
+nnutxos=$(<nn.utxos)
+nnutxo=$(echo "$nnutxos" | jq --arg amt "$SPLIT_VALUE" '[.[] | select (.amount==($amt|tonumber))] | length')
+if [[ nnutxo != "null" ]]; then
+        if (( nnutxo < SPLIT_THRESHOLD )); then
+                echo "call to split_nn_sapling.sh because $nnutxo < $SPLIT_THRESHOLD"
+                ./split_nn_sapling.sh
+        fi
+fi


### PR DESCRIPTION
I used FSM branch of komodo on the distant KMD node. I tested this script a little bit to split utxo for the 3P NN setup, it worked but I think that we should avoid to rely on only one explorer : if the explorer returns 0 utxo for the NN, we will split loads of utxo, it is not useful. A possible enhancement is to use several explorers (I'd like to avoid to importprivkey of the NN on the distant node).